### PR TITLE
Optimize Trigger Trigger Player collision checks

### DIFF
--- a/Code/TriggerTrigger.cs
+++ b/Code/TriggerTrigger.cs
@@ -59,9 +59,9 @@ namespace vitmod
                 collideEnity = data.Attr("entityType", "");
             }
             collideCount = data.Int("collideCount", 1);
-            entitiesTouched = new List<Entity>();
+            entitiesTouched = new HashSet<Entity>();
             collideSolid = data.Attr("solidType", "");
-            entitiesInside = new List<Entity>();
+            entitiesInside = new HashSet<Entity>();
             Add(new HoldableCollider((Holdable holdable) => {
                 if (activationType == ActivationTypes.OnHoldableEnter)
                 {
@@ -498,27 +498,22 @@ namespace vitmod
             bool result = orig(self, player);
 
             Entity entity = self.Entity;
-            foreach (TriggerTrigger trigger in self.SceneAs<Level>().Tracker.GetEntities<TriggerTrigger>())
-            {
-                if (result)
-                {
-                    if (trigger.activationType == ActivationTypes.OnEntityCollide && VitModule.GetClassName(trigger.collideEnity, entity))
-                    {
-                        if (!trigger.entitiesTouched.Contains(entity))
-                        {
-                            trigger.entitiesTouched.Add(entity);
+            foreach (TriggerTrigger trigger in TriggerTriggers) {
+                if (trigger.activationType == ActivationTypes.OnEntityCollide) {
+                    if (result) {
+                        if (VitModule.GetClassName(trigger.collideEnity, entity) && trigger.entitiesTouched.Add(entity)) {
                             trigger.collideEntityCount++;
                         }
+                    } else {
+                        trigger.entitiesTouched.Remove(entity);
                     }
-                }
-                else if (trigger.entitiesTouched.Contains(entity))
-                {
-                    trigger.entitiesTouched.Remove(entity);
                 }
             }
 
             return result;
         }
+
+        public static List<Entity> TriggerTriggers;
 
         public bool Global;
         public bool Activated;
@@ -535,9 +530,9 @@ namespace vitmod
         public string collideEnity;
         public int collideEntityCount;
         private int collideCount;
-        public List<Entity> entitiesTouched;
+        public HashSet<Entity> entitiesTouched;
         private Session.CoreModes coreMode;
-        private List<Entity> entitiesInside;
+        private HashSet<Entity> entitiesInside;
         private string collideSolid;
         public bool externalActivation;
         private bool invertCondition;

--- a/Code/VitModule.cs
+++ b/Code/VitModule.cs
@@ -454,6 +454,8 @@ namespace vitmod
                 useNoMoveDelta = false;
             }
 
+            TriggerTrigger.TriggerTriggers = self.Tracker.GetEntities<TriggerTrigger>();
+
             orig(self);
         }
 


### PR DESCRIPTION
The player collide hook in trigger triggers is extremely inefficient as it is called once for each collidable entity in a room every frame. This PR keeps a separate list of trigger triggers currently in the level to reduce the number of calls to `GetEntities`.
The PR also changes the `entitiesTouched` and `entitiesInside` Lists into HashSets as the order isn't needed for either, greatly improving performance of calls such as `Add`. Furthermore, the number of calls to `entitiesTouched` per iteration has been cut in half. In one particularly large room, this alone reduced the time `Player.Update` took from 3.65ms down to 2.95ms.

I do not know how safe it is to keep a separate list of trigger triggers in a static field like this. If there is a better way to do it, feel free to change it.