### PR TITLE
Massively optimise `Update On Entry` Depth Triggers

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -235,6 +235,7 @@ placements.triggers.vitellary/editdepthtrigger.tooltips.depth=New depth to set t
 placements.triggers.vitellary/editdepthtrigger.tooltips.entitiesToAffect=The class name of the entity to alter. Can be a comma separated list of multiple entity types as well.
 placements.triggers.vitellary/editdepthtrigger.tooltips.debug=If true, then Celeste will write the names of all entities touching the trigger in the log (can be seen in log.txt immediately), as well as their current depths. Useful to figure out the names of the entities you'd like to affect, though remember to disable the option later.
 placements.triggers.vitellary/editdepthtrigger.tooltips.updateOnEntry=If true, the trigger will affect entities that move into it; otherwise, it will only affect entities that are touching it when the room loads.
+placements.triggers.vitellary/editdepthtrigger.tooltips.cacheValidEntities=If 'Update On Entry' is enabled, then all entities that pass the type filter will get cached, massively improving performance.\nOnly disable if you want to edit the depth of entities that get dynamically added to the level after its loaded, like debris.
 
 # Bloom Strength Trigger
 placements.triggers.vitellary/bloomstrengthtrigger.tooltips.bloomStrengthFrom=Determines where the bloom strength starts.

--- a/Ahorn/triggers/editDepthTrigger.jl
+++ b/Ahorn/triggers/editDepthTrigger.jl
@@ -5,7 +5,7 @@ using ..Ahorn, Maple
 @mapdef Trigger "vitellary/editdepthtrigger" NewDepth(x::Integer, y::Integer,
     width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight,
     depth::Integer=-9000, entitiesToAffect::String="Celeste.MoveBlock", debug::Bool=false,
-    updateOnEntry::Bool=false)
+    updateOnEntry::Bool=false, cacheValidEntities::Bool=true)
 
 const placements = Ahorn.PlacementDict(
     "Edit Depth Trigger (Crystalline)" => Ahorn.EntityPlacement(

--- a/Code/TypeHelper.cs
+++ b/Code/TypeHelper.cs
@@ -1,0 +1,50 @@
+﻿using Celeste.Mod;
+using Celeste.Mod.Helpers;
+using Monocle;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace vitmod {
+    /// <summary>
+    /// Provides utility functions for turning strings to types
+    /// </summary>
+    internal static class TypeHelper {
+        private static Dictionary<string, HashSet<Type>> TypeListCache = new(StringComparer.Ordinal);
+        private static Type[] AllEntityTypes;
+
+        /// <summary>
+        /// Parses a comma-seperated list of c# type full names or short names. Cached.
+        /// </summary>
+        public static HashSet<Type> ParseTypeList(string list) {
+            if (TypeListCache.TryGetValue(list, out var result)) {
+                return result;
+            }
+
+            var split = list.Split(',');
+
+            AllEntityTypes ??= FakeAssembly.GetFakeEntryAssembly().GetTypes().Where(t => t.IsSubclassOf(typeof(Entity))).ToArray();
+
+            result = new(AllEntityTypes.Where(t => split.Contains(t.FullName, StringComparer.Ordinal) || split.Contains(t.Name, StringComparer.Ordinal)));
+            TypeListCache[list] = result;
+
+            return result;
+        }
+
+        internal static void Load() {
+            On.Celeste.Mod.Everest.Loader.LoadModAssembly += Loader_LoadModAssembly;
+        }
+
+        internal static void Unload() {
+            On.Celeste.Mod.Everest.Loader.LoadModAssembly -= Loader_LoadModAssembly;
+        }
+
+        // Clear the cache if a mod is loaded/hot reloaded
+        private static void Loader_LoadModAssembly(On.Celeste.Mod.Everest.Loader.orig_LoadModAssembly orig, EverestModuleMetadata meta, Assembly asm) {
+            orig(meta, asm);
+            AllEntityTypes = null;
+            TypeListCache.Clear();
+        }
+    }
+}

--- a/Code/VitModule.cs
+++ b/Code/VitModule.cs
@@ -264,6 +264,7 @@ namespace vitmod
                 Version = new Version(1, 5, 4)
             });
 
+            TypeHelper.Load();
             NoJumpTrigger.Load();
             NoDashTrigger.Load();
             NoGrabTrigger.Load();
@@ -766,6 +767,8 @@ namespace vitmod
 
         public override void Unload()
         {
+            TypeHelper.Unload();
+
             NoJumpTrigger.Unload();
             NoDashTrigger.Unload();
             NoGrabTrigger.Unload();

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -344,6 +344,7 @@ triggers.vitellary/editdepthtrigger.attributes.description.depth=New depth to se
 triggers.vitellary/editdepthtrigger.attributes.description.entitiesToAffect=The class name of the entity to alter. Can be a comma separated list of multiple entity types as well.
 triggers.vitellary/editdepthtrigger.attributes.description.debug=If true, then Celeste will write the names of all entities touching the trigger in the log (can be seen in log.txt immediately), as well as their current depths. Useful to figure out the names of the entities you'd like to affect, though remember to disable the option later.
 triggers.vitellary/editdepthtrigger.attributes.description.updateOnEntry=If true, the trigger will affect entities that move into it; otherwise, it will only affect entities that are touching it when the room loads.
+triggers.vitellary/editdepthtrigger.attributes.description.cacheValidEntities=If 'Update On Entry' is enabled, then all entities that pass the type filter will get cached, massively improving performance.\nOnly disable if you want to edit the depth of entities that get dynamically added to the level after its loaded, like debris.
 
 # Bloom Strength Trigger
 triggers.vitellary/bloomstrengthtrigger.attributes.description.bloomStrengthFrom=Determines where the bloom strength starts.

--- a/Loenn/triggers/edit_depth_trigger.lua
+++ b/Loenn/triggers/edit_depth_trigger.lua
@@ -45,7 +45,8 @@ editDepthTrigger.placements = {
             depth = -9000,
             entitiesToAffect = "Celeste.MoveBlock",
             debug = false,
-            updateOnEntry = false
+            updateOnEntry = false,
+            cacheValidEntities = true,
         }
     }
 }


### PR DESCRIPTION
* Instead of doing string comparisons on each entity, they now convert the strings to `Type`s stored in a `HashSet`.
* Added an option `cacheValidEntities`, which, if `updateOnEntry` is enabled, will cache the entities that matched the type filter, so that a smaller amount of entities is checked each frame. This cannot be enabled by default on old triggers, as it's a potentially breaking change for entities added to the level after Awake is called.