### PR TITLE
Update GameplayStats during time freeze

### DIFF
--- a/Code/VitModule.cs
+++ b/Code/VitModule.cs
@@ -479,7 +479,7 @@ namespace vitmod
 
                         var timeStopCheck = useTimeStopDelta && !(entity is Player || entity is PlayerDeadBody
                             || entity is TimeCrystal || entity is CrystalStaticSpinner || entity is DustStaticSpinner
-                            || entity is Lookout || entity is FakeWall);
+                            || entity is Lookout || entity is FakeWall || entity is GameplayStats);
                         if (frostHelperLoaded) {
                             timeStopCheck = timeStopCheck && !IsFrostHelperSpinner(entity);
                         }


### PR DESCRIPTION
`GameplayStats` is the berry-per-checkpoint tracker that appears at the bottom of the screen when paused. This fix allows it to remove itself from the screen after unpausing during time freeze.