### PR TITLE
Fix ForceDashCrystal.dirToUse does not reset when scene end

### DIFF
--- a/Code/ForceDashCrystal.cs
+++ b/Code/ForceDashCrystal.cs
@@ -389,6 +389,12 @@ namespace vitmod
             dirToUse = null;
         }
 
+        public override void SceneEnd(Scene scene)
+        {
+            base.SceneEnd(scene);
+            dirToUse = null;
+        }
+
         private void Respawn()
         {
             if (!Collidable)


### PR DESCRIPTION
This fix the issue where if you press F6 while collecting the crystal, you will be forced to dash in the `dirToUse` direction when you return to the level