### PR TITLE
Improve performance by directly accessing private members and replacing DynData with DynamicData

### DIFF
--- a/Code/BoostBumper.cs
+++ b/Code/BoostBumper.cs
@@ -122,8 +122,7 @@ namespace vitmod
                 cannotUseTimer = 0.45f;
                 player.StateMachine.State = 4;
                 player.Speed = Vector2.Zero;
-                DynData<Player> playerData = new DynData<Player>(player);
-                playerData.Set("boostTarget", Center);
+                player.boostTarget = Center;
                 startedBoosting = true;
                 Audio.Play("event:/game/04_cliffside/greenbooster_enter", Position);
                 wiggler.Start();

--- a/Code/FLCC/CassetteFlagController.cs
+++ b/Code/FLCC/CassetteFlagController.cs
@@ -20,12 +20,8 @@ namespace vitmod
         public override void Awake(Scene scene)
         {
             base.Awake(scene);
-            CassetteBlockManager cassette = scene.Tracker.GetEntity<CassetteBlockManager>();
-            if (cassette != null)
-            {
-                cassetteData = new DynData<CassetteBlockManager>(cassette);
-            }
-            else
+            cassetteBlockManager = scene.Tracker.GetEntity<CassetteBlockManager>();
+            if (cassetteBlockManager == null)
             {
                 RemoveSelf();
             }
@@ -34,9 +30,9 @@ namespace vitmod
         public override void Update()
         {
             base.Update();
-            if (cassetteData != null)
+            if (cassetteBlockManager != null)
             {
-                int index = cassetteData.Get<int>("currentIndex");
+                int index = cassetteBlockManager.currentIndex;
                 Session session = SceneAs<Level>().Session;
                 switch (index)
                 {
@@ -68,7 +64,7 @@ namespace vitmod
             }
         }
 
-        private DynData<CassetteBlockManager> cassetteData;
+        private CassetteBlockManager cassetteBlockManager;
 
         private string blueFlag;
         private string pinkFlag;

--- a/Code/FLCC/CustomMovingTouchSwitch.cs
+++ b/Code/FLCC/CustomMovingTouchSwitch.cs
@@ -316,14 +316,12 @@ namespace vitmod
 		public class BasicSwitch : Component, ISwitch
 		{
 			private Celeste.Switch _switch;
-			private DynData<Celeste.Switch> switchData;
 			private bool persistent;
 			private string persistFlag;
 
 			public BasicSwitch() : base(active: true, visible: false)
 			{
 				_switch = new Celeste.Switch(false);
-				switchData = new DynData<Celeste.Switch>(_switch);
 			}
 
 			public override void Added(Entity entity)
@@ -363,8 +361,8 @@ namespace vitmod
 				}
 			}
 
-			public bool Activated { get => _switch.Activated; set => switchData.Set("Activated", value); }
-			public bool Finished { get => _switch.Finished; set => switchData.Set("Finished", value); }
+			public bool Activated { get => _switch.Activated; set => _switch.Activated = value; }
+			public bool Finished { get => _switch.Finished; set => _switch.Finished = value; }
 
 			public Action OnActivate { get => _switch.OnActivate; set => _switch.OnActivate = value; }
 			public Action OnDeactivate { get => _switch.OnDeactivate; set => _switch.OnDeactivate = value; }

--- a/Code/FLCC/CustomPuffer.cs
+++ b/Code/FLCC/CustomPuffer.cs
@@ -251,7 +251,7 @@ namespace vitmod
 			holder = null;
 		}
 
-		protected override void OnSquish(CollisionData data)
+		public override void OnSquish(CollisionData data)
 		{
 			Explode();
 			GotoGone();
@@ -726,7 +726,7 @@ namespace vitmod
 			{
 				return;
 			}
-			if (Hold != null && Input.Grab.Check && !player.Ducking && !new DynData<Player>(player).Get<bool>("IsTired"))
+			if (Hold != null && Input.Grab.Check && !player.Ducking && !player.IsTired)
 				return;
 			if (cannotHitTimer <= 0f)
 			{

--- a/Code/FLCC/DeadlyDashSwitch.cs
+++ b/Code/FLCC/DeadlyDashSwitch.cs
@@ -41,8 +41,7 @@ namespace vitmod
             DashCollisionResults result = orig(self, player, direction);
             if (self is DeadlyDashSwitch)
             {
-                DynData<DashSwitch> switchData = new DynData<DashSwitch>(self);
-                if (!switchData.Get<bool>("pressed"))
+                if (!self.pressed)
                 {
                     player.Die(Vector2.Clamp(player.Center - self.Center, -Vector2.One, Vector2.One));
                 }

--- a/Code/FLCC/FlagCrystal.cs
+++ b/Code/FLCC/FlagCrystal.cs
@@ -350,7 +350,7 @@ namespace vitmod
             return Speed.Y == 0f && base.IsRiding(solid);
         }
 
-        protected override void OnSquish(CollisionData data)
+        public override void OnSquish(CollisionData data)
         {
             if (!TrySquishWiggle(data))
             {
@@ -396,7 +396,7 @@ namespace vitmod
                 if (Hold.Holder != null)
                     Hold.Holder.Holding = null;
                 Hold.RemoveSelf();
-                new DynData<Holdable>(Hold).Set<Player>("Holder", null);
+                Hold.Holder = null;
                 backSprite.Visible = false;
                 theoSprite.Visible = false;
                 frontSprite.Visible = false;
@@ -412,13 +412,12 @@ namespace vitmod
                 return orig(self);
             }
             bool hasTheo = false;
-            DynData<TempleGate> gateData = new DynData<TempleGate>(self);
             foreach (FlagCrystal crystal in self.SceneAs<Level>().Tracker.GetEntities<FlagCrystal>())
             {
                 if (crystal.isTheo)
                 {
                     hasTheo = true;
-                    if (crystal.X > self.X + 10f || Vector2.DistanceSquared(gateData.Get<Vector2>("holdingCheckFrom"), crystal.Center) < (gateData.Get<bool>("open") ? 6400f : 4096f))
+                    if (crystal.X > self.X + 10f || Vector2.DistanceSquared(self.holdingCheckFrom, crystal.Center) < (self.open ? 6400f : 4096f))
                     {
                         return true;
                     }

--- a/Code/FLCC/InteractiveChaser.cs
+++ b/Code/FLCC/InteractiveChaser.cs
@@ -18,8 +18,13 @@ namespace vitmod
 {
 	[Tracked]
 	[CustomEntity("vitellary/interactivechaser")]
-	public class InteractiveChaser : Entity
-	{
+	public class InteractiveChaser : Entity {
+        private const string vitellaryInteractiveChaserStates = "vitellaryInteractiveChaserStates";
+        private const string vitellaryChaserPosition = "vitellaryChaserPosition";
+        private const string vitellaryChaserMovementCounter = "vitellaryChaserMovementCounter";
+        private const string vitellaryChaserSpeed = "vitellaryChaserSpeed";
+        private const string vitellaryChaserDashed = "vitellaryChaserDashed";
+
 		public static readonly Color HairColor = Calc.HexToColor("9B3FB5");
 
 		public PlayerSprite Sprite;
@@ -313,7 +318,7 @@ namespace vitmod
 		{
 			if (!player.Dead)
 			{
-				var chaserStates = new DynData<Player>(player).Get<List<ChaserState>>("vitellaryInteractiveChaserStates");
+				var chaserStates = DynamicData.For(player).Get<List<ChaserState>>(vitellaryInteractiveChaserStates);
 				bool flag = false;
 				foreach (ChaserState chaserState in chaserStates)
 				{
@@ -353,7 +358,7 @@ namespace vitmod
 			//On.Celeste.Actor.Update += Actor_Update;
 			On.Celeste.Player.UpdateChaserStates += Player_UpdateChaserStates;
 			On.Celeste.Player.OnTransition += Player_OnTransition;
-			
+
 			playerOrigUpdateHook = new ILHook(typeof(Player).GetMethod("orig_Update", BindingFlags.Public | BindingFlags.Instance), Player_orig_Update);
 			playerOrigUpdateHook.Apply();
 		}
@@ -366,7 +371,7 @@ namespace vitmod
 			//On.Celeste.Actor.Update -= Actor_Update;
 			On.Celeste.Player.UpdateChaserStates -= Player_UpdateChaserStates;
 			On.Celeste.Player.OnTransition -= Player_OnTransition;
-			
+
 			playerOrigUpdateHook.Dispose();
 		}
 
@@ -382,7 +387,7 @@ namespace vitmod
 
 		private static void Player_OnTransition(On.Celeste.Player.orig_OnTransition orig, Player self)
 		{
-			var chaserStates = new DynData<Player>(self).Get<List<ChaserState>>("vitellaryInteractiveChaserStates");
+			var chaserStates = DynamicData.For(self).Get<List<ChaserState>>(vitellaryInteractiveChaserStates);
 			chaserStates.Clear();
 			orig(self);
 		}
@@ -411,28 +416,28 @@ namespace vitmod
 
 			cursor.Emit(OpCodes.Ldarg_0);
 			cursor.EmitDelegate<Action<Player>>(player => {
-				var playerData = new DynData<Player>(player);
-				playerData.Set("vitellaryChaserPosition", player.Position);
-				playerData.Set("vitellaryChaserMovementCounter", new DynData<Actor>(player).Get<Vector2>("movementCounter"));
-				playerData.Set("vitellaryChaserSpeed", player.Speed);
+                var playerData = DynamicData.For(player);
+				playerData.Set(vitellaryChaserPosition, player.Position);
+				playerData.Set(vitellaryChaserMovementCounter, player.movementCounter);
+				playerData.Set(vitellaryChaserSpeed, player.Speed);
 				if (player.DashAttacking && player.Speed.Length() > 0f)
-					playerData.Set("vitellaryChaserDashed", player.DashDir);
+					playerData.Set(vitellaryChaserDashed, player.DashDir);
 			});
 		}
 
 		private static void Player_Update(On.Celeste.Player.orig_Update orig, Player self)
 		{
-			new DynData<Player>(self).Set("vitellaryChaserDashed", Vector2.Zero);
+            DynamicData.For(self).Set(vitellaryChaserDashed, Vector2.Zero);
 			orig(self);
 		}
 
 		private static void Player_ctor(On.Celeste.Player.orig_ctor orig, Player self, Vector2 position, PlayerSpriteMode spriteMode)
 		{
 			orig(self, position, spriteMode);
-			var playerData = new DynData<Player>(self);
-			playerData.Set("vitellaryInteractiveChaserStates", new List<ChaserState>());
-			playerData.Set("vitellaryChaserPosition", self.Position);
-			playerData.Set("vitellaryChaserSpeed", self.Speed);
+			var playerData = DynamicData.For(self);
+			playerData.Set(vitellaryInteractiveChaserStates, new List<ChaserState>());
+			playerData.Set(vitellaryChaserPosition, self.Position);
+			playerData.Set(vitellaryChaserSpeed, self.Speed);
 		}
 
 		private static PlayerDeadBody Player_Die(On.Celeste.Player.orig_Die orig, Player self, Vector2 direction, bool evenIfInvincible, bool registerDeathInStats)
@@ -448,7 +453,7 @@ namespace vitmod
 			if (chasers.Count > 0)
 			{
 				var maxDelay = chasers.Max(e => (e as InteractiveChaser).FollowDelay);
-				var chaserStates = new DynData<Player>(self).Get<List<ChaserState>>("vitellaryInteractiveChaserStates");
+				var chaserStates = DynamicData.For(self).Get<List<ChaserState>>(vitellaryInteractiveChaserStates);
 				while (chaserStates.Count > 0 && self.Scene.TimeActive - chaserStates[0].TimeStamp > maxDelay)
 					chaserStates.RemoveAt(0);
 				chaserStates.Add(new ChaserState(self));
@@ -478,28 +483,22 @@ namespace vitmod
 			public GrabState GrabState { get; set; }
 			public int State { get; set; }
 			public string[] Blacklist { get; set; }
-			
-			private DynData<Player> baseData;
-			private DynData<Actor> actorData;
+
 			private List<Component> newComponents;
 
 			public DummyPlayer(Vector2 position, Vector2 mirror, string[] blacklist) : base(position, PlayerSpriteMode.Badeline)
 			{
-				baseData = new DynData<Player>(this);
-				actorData = new DynData<Actor>(this);
-				var hitboxes = new string[] { "normalHitbox", "duckHitbox", "normalHurtbox", "duckHurtbox" };
-				foreach (var hitboxName in hitboxes)
-				{
-					var hitbox = baseData.Get<Hitbox>(hitboxName);
-					hitbox.Center *= mirror;
-				}
+                normalHitbox.Center *= mirror;
+                duckHitbox.Center *= mirror;
+                normalHurtbox.Center *= mirror;
+                duckHurtbox.Center *= mirror;
 				Blacklist = blacklist;
 			}
 
 			public override void Added(Scene scene)
 			{
-				new DynData<Entity>(this).Set("Scene", scene);
-				baseData.Set("level", scene as Level);
+                Scene = scene;
+                level = scene as Level;
 				Dashes = MaxDashes;
 
 				newComponents = new List<Component>();
@@ -513,15 +512,14 @@ namespace vitmod
 					component.Update();
 
 				var platform = (Platform)CollideFirst<Solid>(Position + Vector2.UnitY) ?? (Platform)CollideFirstOutside<JumpThru>(Position + Vector2.UnitY);
-				if (platform != null)
-				{
-					baseData.Set("onGround", true);
-					baseData.Set("OnSafeGround", platform.Safe);
+				if (platform != null) {
+                    onGround = true;
+                    OnSafeGround = platform.Safe;
 				}
 				else
 				{
-					baseData.Set("onGround", false);
-					baseData.Set("OnSafeGround", false);
+                    onGround = false;
+                    OnSafeGround = false;
 				}
 
 				UpdateCarry();
@@ -534,11 +532,11 @@ namespace vitmod
 				GrabState = state.GrabState;
 				Facing = state.Facing;
 				DashDir = state.DashDir;
-				baseData.Set("dashAttackTimer", DashDir != Vector2.Zero ? 1f : 0f);
+                dashAttackTimer = DashDir != Vector2.Zero ? 1f : 0f;
 				if (DashDir != Vector2.Zero)
 				{
 					Position = state.EarlyPosition;
-					actorData.Set("movementCounter", state.MovementCounter);
+                    movementCounter = state.MovementCounter;
 					MoveH(state.Speed.X * state.DeltaTime, OnCollideH);
 					MoveV(state.Speed.Y * state.DeltaTime, OnCollideV);
 				}
@@ -564,9 +562,9 @@ namespace vitmod
 							Vector2 control = new Vector2(begin.X + Math.Sign(begin.X) * 2f, -14f);
 							SimpleCurve curve = new SimpleCurve(begin, end, control);
 
-							baseData.Set("carryOffset", begin);
+                            carryOffset = begin;
 							var tween = Tween.Create(Tween.TweenMode.Oneshot, Ease.CubeInOut, 0.16f, true);
-							tween.OnUpdate = (t) => baseData.Set("carryOffset", curve.GetPoint(t.Eased));
+							tween.OnUpdate = (t) => carryOffset = curve.GetPoint(t.Eased);
 							AddNew(tween);
 						}
 					}
@@ -584,7 +582,7 @@ namespace vitmod
 				}
 
 				var collider = Collider;
-				Collider = baseData.Get<Hitbox>("hurtbox");
+				Collider = hurtbox;
 				foreach (PlayerCollider playerCollider in Scene.Tracker.GetComponents<PlayerCollider>())
 				{
 					if (playerCollider.Entity == null || !Blacklist.Any((s) => s == playerCollider.Entity.GetType().Name))
@@ -667,26 +665,26 @@ namespace vitmod
 
 			public ChaserState(Player player)
 			{
-				var playerData = new DynData<Player>(player);
+				var playerData = DynamicData.For(player);
 				Exists = true;
 				Bottom = player.BottomCenter;
 				Position = player.Position;
 				TimeStamp = player.Scene.TimeActive;
 				Animation = player.Sprite.CurrentAnimationID;
 				Facing = player.Facing;
-				OnGround = playerData.Get<bool>("onGround");
+				OnGround = player.onGround;
 				HairColor = player.Hair.Color;
 				Depth = player.Depth;
 				Scale = new Vector2(Math.Abs(player.Sprite.Scale.X) * (float)player.Facing, player.Sprite.Scale.Y);
-				EarlyPosition = playerData.Get<Vector2>("vitellaryChaserPosition");
-				MovementCounter = playerData.Get<Vector2>("vitellaryChaserMovementCounter");
-				Speed = playerData.Get<Vector2>("vitellaryChaserSpeed");
-				DashDir = playerData.Get<Vector2>("vitellaryChaserDashed");
+				EarlyPosition = playerData.Get<Vector2>(vitellaryChaserPosition);
+				MovementCounter = playerData.Get<Vector2>(vitellaryChaserMovementCounter);
+				Speed = playerData.Get<Vector2>(vitellaryChaserSpeed);
+				DashDir = playerData.Get<Vector2>(vitellaryChaserDashed);
 				DeltaTime = Engine.DeltaTime;
 				Ducking = player.Ducking;
 				State = player.StateMachine.State;
 				GrabState = player.Ducking ? GrabState.Drop : ((Input.Grab.Check && DashDir == Vector2.Zero) ? GrabState.Held : (Input.MoveY == 1 ? GrabState.Drop : GrabState.None));
-				List<Player.ChaserStateSound> activeSounds = playerData.Get<List<Player.ChaserStateSound>>("activeSounds");
+				List<Player.ChaserStateSound> activeSounds = player.activeSounds;
 				Sounds = Math.Min(5, activeSounds.Count);
 				sound0 = ((Sounds > 0) ? activeSounds[0] : default);
 				sound1 = ((Sounds > 1) ? activeSounds[1] : default);

--- a/Code/FLCC/PairedDashSwitch.cs
+++ b/Code/FLCC/PairedDashSwitch.cs
@@ -6,6 +6,7 @@ using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 
 namespace vitmod
 {
@@ -25,6 +26,8 @@ namespace vitmod
 		//public static ParticleType P_PressB;
 		//public static ParticleType P_PressAMirror;
 		//public static ParticleType P_PressBMirror;
+
+        private const string vitellaryPairedSwitches = "vitellaryPairedSwitches";
 
 		private EntityID id;
 		private Vector2? target;
@@ -120,12 +123,12 @@ namespace vitmod
 				if (gate != null)
 				{
 					gate.StartOpen();
-					DynData<TempleGate> gateData = new DynData<TempleGate>(gate);
-					var pairedSwitches = gateData.Get<List<PairedDashSwitch>>("pairedSwitches");
+					var gateData = DynamicData.For(gate);
+					var pairedSwitches = gateData.Get<List<PairedDashSwitch>>(vitellaryPairedSwitches);
 					if (pairedSwitches == null)
 					{
 						pairedSwitches = new List<PairedDashSwitch>();
-						gateData.Set("pairedSwitches", pairedSwitches);
+						gateData.Set(vitellaryPairedSwitches, pairedSwitches);
 					}
 					if (!pairedSwitches.Contains(this))
 						pairedSwitches.Add(this);
@@ -220,14 +223,14 @@ namespace vitmod
 				TempleGate gate = GetGate();
 				if (gate != null)
 				{
-					DynData<TempleGate> gateData = new DynData<TempleGate>(gate);
-					if (!gateData.Get<bool>("open"))
+					var gateData = DynamicData.For(gate);
+					if (!gate.open)
 						gate.Open();
-					var pairedSwitches = gateData.Get<List<PairedDashSwitch>>("pairedSwitches");
+					var pairedSwitches = gateData.Get<List<PairedDashSwitch>>(vitellaryPairedSwitches);
 					if (pairedSwitches == null)
 					{
 						pairedSwitches = new List<PairedDashSwitch>();
-						gateData.Set("pairedSwitches", pairedSwitches);
+						gateData.Set(vitellaryPairedSwitches, pairedSwitches);
 					}
 					if (!pairedSwitches.Contains(this))
 						pairedSwitches.Add(this);
@@ -255,10 +258,10 @@ namespace vitmod
 
 				if (ClaimedGate != null)
 				{
-					DynData<TempleGate> gateData = new DynData<TempleGate>(ClaimedGate);
-					if (gateData.Get<bool>("open"))
+					var gateData = DynamicData.For(ClaimedGate);
+					if (ClaimedGate.open)
 					{
-						var pairedSwitches = gateData.Get<List<PairedDashSwitch>>("pairedSwitches");
+						var pairedSwitches = gateData.Get<List<PairedDashSwitch>>(vitellaryPairedSwitches);
 						if (pairedSwitches == null || (pairedSwitches != null && !pairedSwitches.Any((e) => e != this)))
 						{
 							ClaimedGate.ClaimedByASwitch = false;

--- a/Code/FLCC/TempleGateAllSwitches.cs
+++ b/Code/FLCC/TempleGateAllSwitches.cs
@@ -29,15 +29,13 @@ namespace vitmod
         {
             DashCollisionResults result = orig(self, player, direction);
             bool finalswitch = true;
-            DynData<DashSwitch> switchData = new DynData<DashSwitch>(self);
-            if (switchData.Get<bool>("pressed"))
+            if (self.pressed)
             {
                 foreach (Solid solid in self.SceneAs<Level>().Tracker.GetEntities<Solid>())
                 {
-                    if (solid is DashSwitch)
+                    if (solid is DashSwitch dashSwitch)
                     {
-                        DynData<DashSwitch> otherSwitchData = new DynData<DashSwitch>(solid as DashSwitch);
-                        if (!otherSwitchData.Get<bool>("pressed"))
+                        if (!dashSwitch.pressed)
                         {
                             finalswitch = false;
                             break;

--- a/Code/ForceJumpCrystal.cs
+++ b/Code/ForceJumpCrystal.cs
@@ -166,11 +166,10 @@ namespace vitmod
 
         private void OnPlayer(Player player)
         {
-            DynData<Player> playerData = new DynData<Player>(player);
             player.StateMachine.State = 0;
             if (player.DashAttacking)
             {
-                if (playerData.Get<bool>("SuperWallJumpAngleCheck"))
+                if (player.SuperWallJumpAngleCheck)
                 {
                     if ((bool)m_WallJumpCheck.Invoke(player, new object[] { -1 }))
                     {
@@ -278,7 +277,7 @@ namespace vitmod
         public static ParticleType P_Glow;
 
         public static ParticleType P_Regen;
-        
+
         public static ParticleType P_Shatter;
 
         //functions for making player jump

--- a/Code/KaizoBlock.cs
+++ b/Code/KaizoBlock.cs
@@ -78,9 +78,8 @@ namespace vitmod
             player.Speed.Y = 160f;
             player.StateMachine.State = 0;
             player.NaiveMove(new Vector2(0, Bottom - player.Top));
-            DynData<Player> playerData = new DynData<Player>(player);
-            playerData.Set("dashCooldownTimer", dashDisable);
-            
+            player.dashCooldownTimer = dashDisable;
+
             Audio.Play("event:/game/general/thing_booped", Position);
             sprite.Play("flash");
             sprite.Visible = true;

--- a/Code/KeyBerry.cs
+++ b/Code/KeyBerry.cs
@@ -356,13 +356,12 @@ namespace vitmod
 
         private static IEnumerator KeyBerryOpenDoor(LockBlock door)
         {
-            DynData<LockBlock> doorData = new DynData<LockBlock>(door);
-            SoundEmitter emitter = SoundEmitter.Play(doorData.Get<string>("unlockSfxName"), door);
+            SoundEmitter emitter = SoundEmitter.Play(door.unlockSfxName, door);
             emitter.Source.DisposeOnTransition = true;
             Level level = door.SceneAs<Level>();
             yield return 0.15f;
             door.UnlockingRegistered = true;
-            if (doorData.Get<bool>("stepMusicProgress"))
+            if (door.stepMusicProgress)
             {
                 AudioTrackState music = level.Session.Audio.Music;
                 int progress = music.Progress;
@@ -374,10 +373,10 @@ namespace vitmod
             door.Tag |= Tags.TransitionUpdate;
             door.Collidable = false;
             emitter.Source.DisposeOnTransition = false;
-            yield return doorData.Get<Sprite>("sprite").PlayRoutine("open", false);
+            yield return door.sprite.PlayRoutine("open", false);
             level.Shake(0.3f);
             Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
-            yield return doorData.Get<Sprite>("sprite").PlayRoutine("burst", false);
+            yield return door.sprite.PlayRoutine("burst", false);
             door.RemoveSelf();
             yield break;
         }

--- a/Code/ResetDoorTrigger.cs
+++ b/Code/ResetDoorTrigger.cs
@@ -152,8 +152,7 @@ namespace vitmod
 
         private IEnumerator DoorAnimation(LockBlock door)
         {
-            DynData<LockBlock> doorData = new DynData<LockBlock>(door);
-            Sprite sprite = doorData.Get<Sprite>("sprite");
+            Sprite sprite = door.sprite;
             //reverse is broken, so we have to do it manually
             sprite.Play("burst", true);
             for (int i = sprite.CurrentAnimationTotalFrames-1; i >= 0; i--)
@@ -209,11 +208,10 @@ namespace vitmod
         public static IEnumerator LockBlock_UnlockRoutine(On.Celeste.LockBlock.orig_UnlockRoutine orig, LockBlock self, Follower fol)
         {
             IEnumerator orig_enum = orig(self, fol);
-            DynData<LockBlock> doorData = new DynData<LockBlock>(self);
             CustomWindController wind = self.Scene.Tracker.GetEntity<CustomWindController>();
             while (orig_enum.MoveNext())
             {
-                if (wind != null && wind.activateType == "Locked Door" && doorData.Get<Sprite>("sprite").CurrentAnimationID == "burst")
+                if (wind != null && wind.activateType == "Locked Door" && self.sprite.CurrentAnimationID == "burst")
                 {
                     wind.ActivateWind();
                 }

--- a/Code/VitModule.cs
+++ b/Code/VitModule.cs
@@ -56,7 +56,7 @@ namespace vitmod
         public class VitModuleSettings : EverestModuleSettings
         {
             public TriggerTrigger.RandomizationTypes TriggerTriggerRandomizationType
-            { 
+            {
                 get;
                 set;
             } = TriggerTrigger.RandomizationTypes.FileTimer;
@@ -670,14 +670,18 @@ namespace vitmod
 
         private void Player_CallDashEvents(On.Celeste.Player.orig_CallDashEvents orig, Player self)
         {
-            foreach (BoostBumper booster in self.Scene.Tracker.GetEntities<BoostBumper>())
+            if (self.Scene != null)
             {
-                if (booster.startedBoosting)
+                foreach (BoostBumper booster in self.Scene.Tracker.GetEntities<BoostBumper>())
                 {
-                    booster.PlayerBoosted(self, self.DashDir);
-                    return;
+                    if (booster.startedBoosting)
+                    {
+                        booster.PlayerBoosted(self, self.DashDir);
+                        return;
+                    }
                 }
             }
+
             orig(self);
         }
 
@@ -804,7 +808,7 @@ namespace vitmod
             PairedDashSwitch.Unload();
             TempleGateAllSwitches.Unload();
             TriggerBeam.Unload();
-            
+
             On.Celeste.Level.Update -= Level_Update;
             IL.Monocle.EntityList.Update -= EntityList_Update;
             IL.Monocle.RendererList.Update -= RendererList_Update;

--- a/Code/VitMoveBlock.cs
+++ b/Code/VitMoveBlock.cs
@@ -851,9 +851,8 @@ namespace vitmod
 					firstHit = false;
 				};
 			}
-			protected override void OnSquish(CollisionData data)
-			{
-			}
+			public override void OnSquish(CollisionData data) { }
+
 			public VitMoveBlock.Debris Init(Vector2 position, Vector2 center, Vector2 returnTo)
 			{
 				Collidable = true;

--- a/Code/vitmod.csproj
+++ b/Code/vitmod.csproj
@@ -21,10 +21,11 @@
 
     <ItemGroup>
         <PackageReference Include="MonoMod.RuntimeDetour" Version="22.01.04.03" />
+        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="$(CelestePrefix)\Celeste.exe" />
+        <Reference Include="$(CelestePrefix)\Celeste.exe" Publicize="true" />
         <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll" />
         <Reference Include="lib-stripped\FrostTempleHelper.dll" />
         <Reference Include="lib-stripped\VivHelper.dll" />
@@ -50,11 +51,11 @@
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="bin" />
     </Target>
-    
+
     <PropertyGroup>
         <PathMap>$(MSBuildProjectDirectory)=CrystallineHelper/</PathMap>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     </PropertyGroup>

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,7 +3,7 @@
   DLL: Code/bin/vitmod.dll
   Dependencies:
     - Name: Everest
-      Version: 1.2002.0
+      Version: 1.2840.0
   OptionalDependencies:
     - Name: FrostHelper
       Version: 1.21.2


### PR DESCRIPTION
directly accessing private members by https://github.com/BepInEx/BepInEx.AssemblyPublicizer
use DynamicData.For() instead of the expensive new DynData(), since DynamicData.For() only create the dynamicData once, and reuse it each time it is required