### PR TITLE
fix jank nodash trigger behavior

### DIFF
--- a/Code/NoDashTrigger.cs
+++ b/Code/NoDashTrigger.cs
@@ -21,7 +21,7 @@ namespace vitmod
         public static void Load()
         {
             // On.Celeste.Player.StartDash += Player_StartDash;
-            hook = new Hook(typeof(Player).GetProperty("CanDash", BindingFlags.Public | BindingFlags.Instance).GetMethod, Player_CanDash);
+            hook = new Hook(typeof(Player).GetProperty("CanDash", BindingFlags.Public | BindingFlags.Instance).GetMethod, typeof(NoDashTrigger).GetMethod("Player_CanDash", BindingFlags.Public | BindingFlags.Static));
             hook.Apply();
         }
 

--- a/Code/NoDashTrigger.cs
+++ b/Code/NoDashTrigger.cs
@@ -2,9 +2,11 @@
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod.RuntimeDetour;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,14 +16,19 @@ namespace vitmod
     [Tracked(false)]
     public class NoDashTrigger : Trigger
     {
+        public static Hook hook;
+        public delegate bool orig_CanDash(Player self);
         public static void Load()
         {
-            On.Celeste.Player.StartDash += Player_StartDash;
+            // On.Celeste.Player.StartDash += Player_StartDash;
+            hook = new Hook(typeof(Player).GetProperty("CanDash", BindingFlags.Public | BindingFlags.Instance).GetMethod, Player_CanDash);
+            hook.Apply();
         }
 
         public static void Unload()
         {
-            On.Celeste.Player.StartDash -= Player_StartDash;
+            // On.Celeste.Player.StartDash -= Player_StartDash;
+            hook.Dispose();
         }
 
         public NoDashTrigger(EntityData data, Vector2 offset) : base(data, offset) { }
@@ -32,6 +39,13 @@ namespace vitmod
             {
                 self.Speed -= (Vector2) self.GetType().GetProperty("LiftBoost", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).GetValue(self);
                 return self.StateMachine.State;
+            }
+            return orig(self);
+        }
+
+        public static bool Player_CanDash(orig_CanDash orig, Player self) {
+            if (!self.Dead && self.CollideCheck<NoDashTrigger>()) {
+                return false;
             }
             return orig(self);
         }


### PR DESCRIPTION
originally i just hooked StartDash and made it so it didn't put the player in the Dash state, but doing this made it so that speed was slightly altered when dash was pressed. this changes it so that we hook CanDash instead which stops dashing from happening at all

resolves issue #19 