### PR TITLE
adjust custom heart dash refilling

### DIFF
--- a/Code/FLCC/CustomHeartGem.cs
+++ b/Code/FLCC/CustomHeartGem.cs
@@ -327,11 +327,9 @@ namespace vitmod
 				Audio.Play("event:/game/general/crystalheart_bounce", Position);
 				bounceSfxDelay = 0.1f;
 			}
-			player.PointBounce(base.Center);
-			if (dashCount != 1)
-            {
-				player.Dashes = dashCount;
-            }
+            var dashes = Math.Max(player.Dashes, dashCount);
+            player.PointBounce(base.Center);
+            player.Dashes = dashes;
 			moveWiggler.Start();
 			ScaleWiggler.Start();
 			moveWiggleDir = (base.Center - player.Center).SafeNormalize(Vector2.UnitY);
@@ -365,7 +363,7 @@ namespace vitmod
 				}
 				if (!endLevel)
 				{
-					player?.RefillDash();
+                    player.Dashes = Math.Max(player.Dashes, dashCount);
 				}
 				if (slowdown)
 				{


### PR DESCRIPTION
no longer will set your dash count to a number lower than your current dash count, and will properly set your dash count upon breaking the heart

technically a breaking change, i suppose, if a map previously depended on the specific inconsistent dash amount you'd receive from the heart's various interactions. to my knowledge there isn't a map that uses this though, and there are maps in development that would prefer this changed (this was a request from someone else)