### PR TITLE
fixed inaccurate boost behavior with custom puffer

### DIFF
--- a/Code/FLCC/CustomPuffer.cs
+++ b/Code/FLCC/CustomPuffer.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste;
+using Celeste.Mod;
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -74,6 +75,7 @@ namespace vitmod
 		private Color outlineColor = Color.White;
 		private bool canUpdateHome = false;
 		private bool holdFlip = false;
+        private bool legacyBoost = true;
 
 		public CustomPuffer(Vector2 position, bool faceRight, float angle = 0f, float radius = 32f, float launchSpeed = 280f, string spriteName = "pufferFish")
 			: base(position)
@@ -129,6 +131,7 @@ namespace vitmod
 			canUpdateHome = !data.Bool("returnToStart", true);
 			holdFlip = data.Bool("holdFlip");
 			boostMode = data.Enum("boostMode", BoostModes.SetSpeed);
+            legacyBoost = data.Bool("legacyBoost", true);
 
 			if (data.Bool("holdable"))
 			{
@@ -794,8 +797,13 @@ namespace vitmod
 			}
 			if (Input.MoveX.Value == Math.Sign(player.Speed.X))
 			{
-				player.Speed.X *= 1.2f;
-			}
+                player.explodeLaunchBoostTimer = 0f;
+                player.Speed.X *= 1.2f;
+            } else if (!legacyBoost) {
+                // not sure why, but this doesn't work if we use 0.01f the same way the vanilla puffer does
+                player.explodeLaunchBoostTimer = 0.02f;
+                player.explodeLaunchBoostSpeed = player.Speed.X * 1.2f;
+            }
 			SlashFx.Burst(player.Center, player.Speed.Angle());
 			if (!player.Inventory.NoRefills)
 			{

--- a/Loenn/entities/custom_puffer.lua
+++ b/Loenn/entities/custom_puffer.lua
@@ -21,6 +21,7 @@ customPuffer.placements = {
             returnToStart = true,
             holdFlip = false,
             boostMode = "SetSpeed",
+            legacyBoost = false,
         }
     },
     {
@@ -42,6 +43,7 @@ customPuffer.placements = {
             returnToStart = true,
             holdFlip = false,
             boostMode = "SetSpeed",
+            legacyBoost = false,
         }
     }
 }

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -198,6 +198,7 @@ entities.vitellary/custompuffer.attributes.description.outlineColor=The color of
 entities.vitellary/custompuffer.attributes.description.returnToStart=Whether the puffer will respawn at its starting position.
 entities.vitellary/custompuffer.attributes.description.holdFlip=Whether the puffer will flip with the player when held.
 entities.vitellary/custompuffer.attributes.description.boostMode=The way the puffer's explosion should affect the player.\nSet Speed: Default puffer behavior, sets the player's speed to the launch speed in the angle specified.\nRedirect Speed: If the player has a greater speed than the launch speed specified, apply that speed to the new angle instead.\nRedirect + Add Speed: Takes the player's current speed and redirects it, then adds the puffer's launch speed as well.
+entities.vitellary/custompuffer.attributes.description.legacyBoost=Whether the puffer boost should use the older, less lenient method of checking player input (only accepting input before the freeze frames, rather than after).
 
 # Energy Booster
 entities.vitellary/energybooster.attributes.description.behaveLikeDash=Whether the speed resets after the initial boost unless dashing down diagonal.


### PR DESCRIPTION
this was originally a request to add a "Legacy Boost" option which made the puffer boost behave how it did in the past... until i realized that that's apparently what the code was actually doing already, and so puffer boosts have had incorrect behavior for a while now. the "legacy boost" option will be on for puffers that don't have the field initialized, so this won't affect any previous maps, but newly placed puffers should now have the accurate and lenient boost behavior by default