### PR TITLE
set boostRed to false when touching energy booster

### DIFF
--- a/Code/FLCC/EnergyBooster.cs
+++ b/Code/FLCC/EnergyBooster.cs
@@ -101,6 +101,7 @@ namespace vitmod
 			if (respawnTimer <= 0f && cannotUseTimer <= 0f && BoostingPlayer == null)
 			{
 				cannotUseTimer = 0.45f;
+				player.boostRed = false;
 				player.StateMachine.State = 4;
 				PlayerSpeed = player.Speed;
 				if (player.LiftSpeed != Vector2.Zero)


### PR DESCRIPTION
previously, a niche bug occurred where, if you had touched a red booster and hadn't died since then, the energy booster would retain the properties of the red booster. very easy to fix