### PR TITLE
add "Any" input & "Hold Input" options

### DIFF
--- a/Code/TriggerTrigger.cs
+++ b/Code/TriggerTrigger.cs
@@ -1,10 +1,12 @@
 ﻿using Celeste;
 using Celeste.Mod.Entities;
+using FMOD;
 using Microsoft.Xna.Framework;
 using Monocle;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace vitmod {
     [CustomEntity("vitellary/triggertrigger")]
@@ -47,6 +49,24 @@ namespace vitmod {
             waitTime = data.Float("timeToWait", 0f);
             coreMode = data.Enum("coreMode", Session.CoreModes.None);
             inputType = data.Enum("inputType", InputTypes.Grab);
+            if (data.Has("holdInput")) {
+                inputHeld = data.Bool("holdInput");
+            } else {
+                // account for previous behavior:
+                // if it's a direction, use whether the direction is held
+                // otherwise, just check if it's pressed
+                switch (inputType) {
+                    case InputTypes.Left:
+                    case InputTypes.Right:
+                    case InputTypes.Up:
+                    case InputTypes.Down:
+                        inputHeld = true;
+                        break;
+                    default:
+                        inputHeld = false;
+                        break;
+                }
+            }
             ifSafe = data.Bool("onlyIfSafe", false);
             if (string.IsNullOrEmpty(data.Attr("entityType", ""))) {
                 collideType = data.Attr("entityTypeToCollide", "Celeste.Strawberry");
@@ -284,34 +304,15 @@ namespace vitmod {
                     }
                     break;
                 case ActivationTypes.OnInput:
-                    switch (inputType) {
-                        case InputTypes.Grab:
-                            result = Input.Grab.Pressed;
-                            break;
-                        case InputTypes.Jump:
-                            result = Input.Jump.Pressed;
-                            break;
-                        case InputTypes.Dash:
-                            result = Input.Dash.Pressed;
-                            break;
-                        case InputTypes.Interact:
-                            result = Input.Talk.Pressed;
-                            break;
-                        case InputTypes.CrouchDash:
-                            result = Input.CrouchDash.Pressed;
-                            break;
-                        default:
-                            Vector2 aim = Input.Aim.Value.FourWayNormal();
-                            if (inputType == InputTypes.Left && aim.X < 0f)
+                    if (inputType != InputTypes.Any) {
+                        result = CheckInput(inputType, inputHeld);
+                    } else {
+                        foreach (InputTypes input in Enum.GetValues<InputTypes>()) {
+                            if (CheckInput(input, inputHeld)) {
                                 result = true;
-                            else if (inputType == InputTypes.Right && aim.X > 0f)
-                                result = true;
-                            else if (inputType == InputTypes.Down &&  aim.Y > 0f)
-                                result = true;
-                            else if (inputType == InputTypes.Up  && aim.Y < 0f)
-                                result = true;
-
-                            break;
+                                break;
+                            }
+                        }
                     }
                     break;
                 case ActivationTypes.OnGrounded:
@@ -448,6 +449,35 @@ namespace vitmod {
             yield break;
         }
 
+        private bool CheckInput(InputTypes inputType, bool held) {
+            switch (inputType) {
+                case InputTypes.Grab:
+                    return (held ? Input.Grab.Check : Input.Grab.Pressed);
+                case InputTypes.Jump:
+                    return (held ? Input.Jump.Check : Input.Jump.Pressed);
+                case InputTypes.Dash:
+                    return (held ? Input.Dash.Check : Input.Dash.Pressed);
+                case InputTypes.Interact:
+                    return (held ? Input.Talk.Check : Input.Talk.Pressed);
+                case InputTypes.CrouchDash:
+                    return (held ? Input.CrouchDash.Check : Input.CrouchDash.Pressed);
+                default:
+                    Vector2 aim = Input.Aim.Value.FourWayNormal();
+                    if (held || (aim != Input.Aim.PreviousValue.FourWayNormal())) {
+                        if (inputType == InputTypes.Left && aim.X < 0f)
+                            return true;
+                        else if (inputType == InputTypes.Right && aim.X > 0f)
+                            return true;
+                        else if (inputType == InputTypes.Down && aim.Y > 0f)
+                            return true;
+                        else if (inputType == InputTypes.Up && aim.Y < 0f)
+                            return true;
+                    }
+                    break;
+            }
+            return false;
+        }
+
         private static void Player_Jump(On.Celeste.Player.orig_Jump orig, Player self, bool particles, bool playSfx) {
             orig(self, particles, playSfx);
             if (self == null) { return; }
@@ -513,6 +543,7 @@ namespace vitmod {
         private int collideCount;
         private Session.CoreModes coreMode;
         private InputTypes inputType;
+        private bool inputHeld;
         private bool ifSafe;
         private TalkComponent talker;
         private List<Entity> entitiesInside;
@@ -566,6 +597,7 @@ namespace vitmod {
             Grab,
             Interact,
             CrouchDash,
+            Any,
         };
         private static List<ActivationTypes> bypassGlobal = new List<ActivationTypes>() {
             ActivationTypes.OnHoldableEnter,

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -366,6 +366,7 @@ triggers.vitellary/triggertrigger.attributes.description.coreMode=Core mode the 
 triggers.vitellary/triggertrigger.attributes.description.entityType=Class name of the type of entity to check.
 triggers.vitellary/triggertrigger.attributes.description.solidType=Class name of the type of solid to check. If left blank, the trigger will allow any solids to be considered.
 triggers.vitellary/triggertrigger.attributes.description.inputType=The type of input the player needs to press.
+triggers.vitellary/triggertrigger.attributes.description.holdInput=Whether the trigger will be active for the entire time the input is held, or just for the frame it's pressed.
 triggers.vitellary/triggertrigger.attributes.description.onlyIfSafe=Whether the floor the player is standing on needs to be safe ground (aka. ground that a berry could be collected on).
 
 # Edit Depth Trigger

--- a/Loenn/triggers/trigger_trigger.lua
+++ b/Loenn/triggers/trigger_trigger.lua
@@ -38,6 +38,7 @@ local inputTypes = {
     "Grab",
     "Interact",
     "CrouchDash",
+    "Any",
 }
 
 local triggerTrigger = {}
@@ -85,6 +86,7 @@ function triggerTrigger.ignoredFields(entity)
         "solidType",
         "entityType",
         "inputType",
+        "holdInput",
         "onlyIfSafe",
     }
 
@@ -129,6 +131,7 @@ function triggerTrigger.ignoredFields(entity)
         doNotIgnore("entityType")
     elseif atype == "OnInput" then
         doNotIgnore("inputType")
+        doNotIgnore("holdInput")
     elseif atype == "OnGrounded" then
         doNotIgnore("onlyIfSafe")
     end
@@ -169,6 +172,7 @@ for _, mode in pairs(activationTypes) do
             solidType = "",
             entityType = "",
             inputType = "Grab",
+            holdInput = false,
             onlyIfSafe = false,
         }
     }


### PR DESCRIPTION
"Hold Input" option was added because previous behavior was inconsistent and it needed to be made consistent for the Any option to work well. default undefined behavior should line up with how it was working before the option was added, in case any maps used either behavior as it was before