### PR TITLE
forcibly add coyote frames to fast ice block

### DIFF
--- a/Code/FLCC/FastBounceBlock.cs
+++ b/Code/FLCC/FastBounceBlock.cs
@@ -75,6 +75,7 @@ namespace vitmod
                     {
                         if (iceMode)
                         {
+                            player2.StartJumpGraceTime();
                             Break();
                             break;
                         }


### PR DESCRIPTION
there is a 100% chance that i'm the only one that's ever used this entity so i feel no remorse in adding stuff to it that retroactively adds mechanics to it. it's currently frame perfect, i believe, to both activate the block from its side and climbjump, so this will allow it to be as precise as a jump off the top of it would be. also lets you do weird core hyper kinda thing but without momentum