### PR TITLE
move resetActivation to update

### DIFF
--- a/Code/TriggerTrigger.cs
+++ b/Code/TriggerTrigger.cs
@@ -187,6 +187,12 @@ namespace vitmod {
                     UpdateTriggers(player);
                 }
             }
+
+            if (resetActivation)
+            {
+                externalActivation = false;
+                resetActivation = false;
+            }
         }
 
         public void UpdateConditions(Player player) {
@@ -337,11 +343,6 @@ namespace vitmod {
             }
             if (externalActivation) {
                 result = true;
-                if (resetActivation)
-                {
-                    externalActivation = false;
-                    resetActivation = false;
-                }
             }
             if (invertCondition) {
                 result = !result;


### PR DESCRIPTION
fixes an issue where activating an input trigger trigger during freeze frames would buffer an activation for every trigger trigger in the room