### PR TITLE
Fix EnergyBooster's VertexLight not disappearing at the right time when oneUse is enabled

### DIFF
--- a/Code/FLCC/EnergyBooster.cs
+++ b/Code/FLCC/EnergyBooster.cs
@@ -136,6 +136,8 @@ namespace vitmod
 			player.Speed = newSpeed;
 			if (!oneUse) {
 				outline.Visible = true;
+			} else {
+				Remove(light);
 			}
 			wiggler.Start();
 			//PlayerReleased(player);


### PR DESCRIPTION
Previously the booster would not remove its light until it was itself removed, which looked bad. Now the light gets removed as soon as the player uses the booster.