### PR TITLE
Add option to use vanilla particles and custom fill color to Flag Kevins

### DIFF
--- a/Code/FLCC/FlagKevin.cs
+++ b/Code/FLCC/FlagKevin.cs
@@ -28,11 +28,12 @@ namespace vitmod
             }
         }
 
-        public static ParticleType P_Impact => CrushBlock.P_Impact;
-        public static ParticleType P_Crushing => CrushBlock.P_Impact;
-        public static ParticleType P_Activate => CrushBlock.P_Impact;
+        private readonly bool useVanillaParticles;
+        public ParticleType P_Impact => CrushBlock.P_Impact;
+        public ParticleType P_Crushing => useVanillaParticles ? CrushBlock.P_Crushing : CrushBlock.P_Impact;
+        public ParticleType P_Activate => useVanillaParticles ? CrushBlock.P_Activate : CrushBlock.P_Impact;
 
-        private Color fill = Calc.HexToColor("62222b");
+        private Color fill;
         private Level level;
         private bool canActivate;
         private Vector2 crushDir;
@@ -80,8 +81,9 @@ namespace vitmod
 
         public FlagKevin(Vector2 position, float width, float height, Axes axes, MoveBlock.Directions _flagDirection,
             string _flag, bool _inverted = false, bool chillOut = false, float _lavaSpeed = 1, string customPath = null,
-            bool _playerHit = true, bool _repeat = false, bool _setFlagOnHit = false,
-            float _crushSpeed = 240f, float _returnSpeed = 60f, float _crushAccel = 500f, float _returnAccel = 160f)
+            Color? fillColor = null, bool _playerHit = true, bool _repeat = false, bool _setFlagOnHit = false,
+            bool _useVanillaParticles = false, float _crushSpeed = 240f, float _returnSpeed = 60f, float _crushAccel = 500f,
+            float _returnAccel = 160f)
             : base(position, width, height, safe: false)
         {
             flag = _flag;
@@ -91,6 +93,8 @@ namespace vitmod
             playerHit = _playerHit;
             repeat = _repeat;
             setFlagOnHit = _setFlagOnHit;
+            useVanillaParticles = _useVanillaParticles;
+            fill = fillColor ?? Calc.HexToColor("62222b");
 
             _CrushSpeed = _crushSpeed;
             _ReturnSpeed = _returnSpeed;
@@ -199,10 +203,11 @@ namespace vitmod
             data.Position + offset, data.Width, data.Height, data.Enum("axes", Axes.Both),
             data.Enum("flagDirection", MoveBlock.Directions.Right), data.Attr("flag"),
             data.Bool("inverted"), data.Bool("chillout"), data.Float("lavaSpeed", 1f),
-            data.Attr("customPath", "crushblock"), data.Bool("playerCanHit", true),
-            data.Bool("repeatWhileFlag"), data.Bool("setFlagOnHit", false),
-            data.Float("crushSpeed", 240f), data.Float("returnSpeed", 60f),
-            data.Float("crushAccel", 500f), data.Float("returnAccel", 160f))
+            data.Attr("customPath", "crushblock"), data.HexColor("fillColor", Calc.HexToColor("62222b")),
+            data.Bool("playerCanHit", true), data.Bool("repeatWhileFlag"), data.Bool("setFlagOnHit", false),
+            data.Bool("useVanillaParticles", false), data.Float("crushSpeed", 240f),
+            data.Float("returnSpeed", 60f), data.Float("crushAccel", 500f),
+            data.Float("returnAccel", 160f))
         { }
 
         public override void Added(Scene scene)

--- a/Loenn/entities/flag_kevin.lua
+++ b/Loenn/entities/flag_kevin.lua
@@ -1,6 +1,7 @@
 local drawableNinePatch = require("structs.drawable_nine_patch")
 local drawableRectangle = require("structs.drawable_rectangle")
 local drawableSprite = require("structs.drawable_sprite")
+local utils = require("utils")
 
 local kevin = {}
 
@@ -18,6 +19,7 @@ kevin.placements = {
             flagDirection = "Right",
             flag = "",
             customPath = "crushblock",
+            fillColor = "62222b",
             inverted = false,
             chillout = false,
             lavaSpeed = 1,
@@ -28,6 +30,7 @@ kevin.placements = {
             playerCanHit = true,
             repeatWhileFlag = false,
             setFlagOnHit = false,
+            useVanillaParticles = false,
         }
     },
     {
@@ -39,6 +42,7 @@ kevin.placements = {
             flagDirection = "Right",
             flag = "",
             customPath = "crushblock",
+            fillColor = "62222b",
             inverted = false,
             chillout = false,
             lavaSpeed = 0.5,
@@ -49,6 +53,7 @@ kevin.placements = {
             playerCanHit = true,
             repeatWhileFlag = false,
             setFlagOnHit = false,
+            useVanillaParticles = false,
         }
     },
 }
@@ -70,13 +75,16 @@ kevin.fieldInformation = {
         options = moveDirections,
         editable = false,
     },
+    fillColor = {
+        fieldType = "color"
+    }
 }
 
 local frameTextures = {
-    none = "objects/crushblock/block00",
-    horizontal = "objects/crushblock/block01",
-    vertical = "objects/crushblock/block02",
-    both = "objects/crushblock/block03"
+    none = "/block00",
+    horizontal = "/block01",
+    vertical = "/block02",
+    both = "/block03"
 }
 
 local ninePatchOptions = {
@@ -84,9 +92,10 @@ local ninePatchOptions = {
     borderMode = "repeat"
 }
 
-local kevinColor = {98 / 255, 34 / 255, 43 / 255}
-local smallFaceTexture = "objects/crushblock/idle_face"
-local giantFaceTexture = "objects/crushblock/giant_block00"
+local defaultPath = "objects/crushblock"
+local defaultColor = {98 / 255, 34 / 255, 43 / 255}
+local smallFaceTexture = "/idle_face"
+local giantFaceTexture = "/giant_block00"
 
 function kevin.sprite(room, entity)
     local x, y = entity.x or 0, entity.y or 0
@@ -95,10 +104,13 @@ function kevin.sprite(room, entity)
     local axes = entity.axes or "both"
     local chillout = entity.chillout
 
-    local giant = height >= 48 and width >= 48 and chillout
-    local faceTexture = giant and giantFaceTexture or smallFaceTexture
+    local path = (entity.customPath ~= nil and entity.customPath ~= "") and ("objects/" .. entity.customPath) or defaultPath
+    local kevinColor = utils.getColor(entity.fillColor or defaultColor)
 
-    local frameTexture = frameTextures[axes] or frameTextures["both"]
+    local giant = height >= 48 and width >= 48 and chillout
+    local faceTexture = path .. (giant and giantFaceTexture or smallFaceTexture)
+
+    local frameTexture = path .. (frameTextures[axes] or frameTextures["both"])
     local ninePatch = drawableNinePatch.fromTexture(frameTexture, ninePatchOptions, x, y, width, height)
 
     local rectangle = drawableRectangle.fromRectangle("fill", x + 2, y + 2, width - 4, height - 4, kevinColor)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -275,6 +275,7 @@ entities.vitellary/interactivechaser.attributes.description.sendToPlayer=If true
 
 # Flag Kevin
 entities.vitellary/flagkevin.attributes.description.customPath=Path to the kevin sprite to use. Relative to Atlases/Gameplay/objects.
+entities.vitellary/flagkevin.attributes.description.fillColor=Fill color for the kevin.
 entities.vitellary/flagkevin.attributes.description.flagDirection=Direction to move when the flag is triggered.
 entities.vitellary/flagkevin.attributes.description.flag=Flag that should trigger the kevin.
 entities.vitellary/flagkevin.attributes.description.inverted=If true, the kevin is triggered when the flag becomes false rather than true.
@@ -284,6 +285,7 @@ entities.vitellary/flagkevin.attributes.description.axes=Determines which sides 
 entities.vitellary/flagkevin.attributes.description.playerCanHit=Whether the player can hit the Kevin's sides.
 entities.vitellary/flagkevin.attributes.description.repeatWhileFlag=If true, the kevin will repeatedly move in the flag direction every time it returns to its initial spot while the flag is true.
 entities.vitellary/flagkevin.attributes.description.setFlagOnHit=If true, the flag will be set to true when the player hits the Kevin.
+entities.vitellary/flagkevin.attributes.description.useVanillaParticles=If true, the kevin will use vanilla activate/crush/impact particles instead of only impact particles.
 entities.vitellary/flagkevin.attributes.description.crushSpeed=The speed at which the Kevin will move when attacking.
 entities.vitellary/flagkevin.attributes.description.returnSpeed=The speed at which the Kevin will move when returning.
 


### PR DESCRIPTION
Adds the option to use the vanilla kevin particles for all actions (activate, crush, impact) instead of only the impact particles. Also adds the option to change the fill color of the kevin (useful for custom sprites). The Loenn plugin has also been changed to properly render custom sprites.