### PR TITLE
Remove `Console.WriteLine`s

### DIFF
--- a/Code/CustomWindController.cs
+++ b/Code/CustomWindController.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste;
+using Celeste.Mod;
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -223,7 +224,7 @@ namespace vitmod
             active = true;
             if (debug && !string.IsNullOrEmpty(activateType))
             {
-                Console.WriteLine("Custom wind doesn't have a activation case for: " + activateType);
+                Logger.Info("CrystallineHelper/CustomWindController", $"Custom wind doesn't have a activation case for: {activateType}");
             }
             if ((speedX.Count > 1 || speedY.Count > 1) && !alternateSpeed.Contains(0))
             {

--- a/Code/EditDepthTrigger.cs
+++ b/Code/EditDepthTrigger.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste;
+using Celeste.Mod;
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -28,7 +29,7 @@ namespace vitmod
                 HandleEntity(entity, fillCache: true);
 
                 if (debug && entity.CollideCheck(this)) {
-                    Console.WriteLine(entity.GetType().FullName + ": " + entity.Depth);
+                    Logger.Info("CrystallineHelper/EditDepthTrigger", $"{entity.GetType().FullName}: {entity.Depth}");
                 }
             }
         }

--- a/Code/FLCC/CustomPlayerHair.cs
+++ b/Code/FLCC/CustomPlayerHair.cs
@@ -42,7 +42,7 @@ namespace vitmod
 
 		public void Start()
 		{
-			Vector2 value = base.Entity.Position + new Vector2((0 - Facing) * 200, 200f);
+			Vector2 value = base.Entity.Position + new Vector2(-(int)Facing * 200, 200f);
 			for (int i = 0; i < Nodes.Count; i++)
 			{
 				Nodes[i] = value;


### PR DESCRIPTION
Stops BananaWatch from yelling about `Console.WriteLines` and uses Everest's `Logger.Info` instead, as well as using string interpolation.
Also fixes a compilation error on the .NET 8 SDK. *(at least I think so)*