### PR TITLE
Fix Timecrystals being eaten by pausing

### DIFF
--- a/Code/TimeCrystal.cs
+++ b/Code/TimeCrystal.cs
@@ -259,8 +259,12 @@ namespace vitmod
 
         public static float stopTimer;
 
+        public static float prevTimer;
+
         public static int stopStage;
 
+        public static int prevStage;
+        
         private Sprite sprite;
 
         private Sprite flash;

--- a/Code/VitModule.cs
+++ b/Code/VitModule.cs
@@ -334,7 +334,7 @@ namespace vitmod
         private void Level_Update(On.Celeste.Level.orig_Update orig, Level self)
         {
             //timestop crystal
-            if (!self.Paused)
+            if (!(self.FrozenOrPaused || self.unpauseTimer>0))
             {
                 if (TimeCrystal.stopTimer > 0f)
                 {
@@ -376,11 +376,9 @@ namespace vitmod
                         }
                     }
                 }
-            }
+            
 
-            if (TimeCrystal.stopStage > 0)
-            {
-                if (!self.Paused)
+                if (TimeCrystal.stopStage > 0)
                 {
                     if (TimeCrystal.timeScaleToSet < 1)
                     {
@@ -390,34 +388,33 @@ namespace vitmod
                     {
                         timeStopScaleTimer -= Engine.DeltaTime;
                     }
-                }
 
-                float timestop_delta_mult = 1;
-                if (TimeCrystal.stopStage == 1)
-                {
-                    timestop_delta_mult = Math.Max(TimeCrystal.timeScaleToSet, 1 - (timeStopScaleTimer / 0.5f));
-                }
-                else if (TimeCrystal.stopStage == 2)
-                {
-                    timestop_delta_mult = Math.Min(1, timeStopScaleTimer / 0.5f);
-                }
+                    float timestop_delta_mult = 1;
+                    if (TimeCrystal.stopStage == 1)
+                    {
+                        timestop_delta_mult = Math.Max(TimeCrystal.timeScaleToSet, 1 - (timeStopScaleTimer / 0.5f));
+                    }
+                    else if (TimeCrystal.stopStage == 2)
+                    {
+                        timestop_delta_mult = Math.Min(1, timeStopScaleTimer / 0.5f);
+                    }
 
-                if (timestop_delta_mult != 1)
-                {
-                    useTimeStopDelta = true;
-                    timeStopDelta = Engine.DeltaTime * timestop_delta_mult;
-                    timeStopRawDelta = Engine.RawDeltaTime * timestop_delta_mult;
+                    if (timestop_delta_mult != 1)
+                    {
+                        useTimeStopDelta = true;
+                        timeStopDelta = Engine.DeltaTime * timestop_delta_mult;
+                        timeStopRawDelta = Engine.RawDeltaTime * timestop_delta_mult;
+                    }
+                    else
+                    {
+                        useTimeStopDelta = false;
+                    }
                 }
                 else
                 {
                     useTimeStopDelta = false;
                 }
             }
-            else
-            {
-                useTimeStopDelta = false;
-            }
-
             //no move trigger
             if (NoMoveTrigger.stopTimer > 0f && !self.Paused)
             {

--- a/Code/VitModule.cs
+++ b/Code/VitModule.cs
@@ -333,9 +333,18 @@ namespace vitmod
 
         private void Level_Update(On.Celeste.Level.orig_Update orig, Level self)
         {
-            //timestop crystal
+            //time crstal
+            if (self.Paused) {
+                //jank because the level becomes "paused" after this update runs, so it's easier to just revert any changes
+                //that might have happened on the next frame (and we are garunteed to have at least one frame with self.Paused=true)
+                TimeCrystal.stopStage = TimeCrystal.prevStage;
+                TimeCrystal.stopTimer = TimeCrystal.prevTimer;
+            }
             if (!(self.FrozenOrPaused || self.unpauseTimer>0))
             {
+                //enable stupid first frame pause reversion
+                TimeCrystal.prevTimer = TimeCrystal.stopTimer;
+                TimeCrystal.prevStage = TimeCrystal.stopStage;
                 if (TimeCrystal.stopTimer > 0f)
                 {
                     TimeCrystal.stopTimer -= Engine.DeltaTime;

--- a/Code/vitmod.csproj
+++ b/Code/vitmod.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>vitmod</AssemblyName>
         <RootNamespace>vitmod</RootNamespace>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Fix Time crystal timers currently tick down during the first frame of a pause and during the unpause animation.
The donet 8 commit is just there to make the compiler happy. The way the first frame issue is resolved is very janky, but it works.

This is a technically a breaking change (as time crystals now check FrozenOrPaused instead of just Paused)