### PR TITLE
Custom Wind Fixes

### DIFF
--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -220,6 +220,7 @@ placements.triggers.vitellary/customwindtrigger.tooltips.loop=Whether the wind s
 placements.triggers.vitellary/customwindtrigger.tooltips.persist=If true, the wind created will stay after transitioning to a different room or dying. It will still be replaced by other wind triggers.
 placements.triggers.vitellary/customwindtrigger.tooltips.oneUse=Whether the wind trigger should disappear after being used.
 placements.triggers.vitellary/customwindtrigger.tooltips.onRoomEnter=Whether the wind trigger should activate immediately when the player enters its room, regardless of the player position.
+placements.triggers.vitellary/customwindtrigger.tooltips.fixUpdateDepth=Whether the wind should always update before the player. If unchecked, whether it updates before or after the player is able to change depending on load order, resulting in inconsistent behavior.
 
 # Player Timestop Trigger
 placements.triggers.vitellary/nomovetrigger.tooltips.stopLength=Determines how long the player will be frozen for.

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -212,7 +212,7 @@ placements.triggers.vitellary/resetdoortrigger.tooltips.onlyInRoom=Whether the t
 
 # Custom Wind Trigger
 placements.triggers.vitellary/customwindtrigger.tooltips.speedX=The horizontal speed of the wind. Can be a list of speeds, separated by commas. For reference, normal wind speed is 4, and strong is 8.
-placements.triggers.vitellary/customwindtrigger.tooltips.speedY=The vertical speed of the wind. Can be a list of speeds, separated by commas. For reference, normal wind speed is 4, and strong is 8.
+placements.triggers.vitellary/customwindtrigger.tooltips.speedY=The vertical speed of the wind. Can be a list of speeds, separated by commas. For reference, normal down wind speed is 3, and up is -4.
 placements.triggers.vitellary/customwindtrigger.tooltips.alternationSpeed=The time, in seconds, that it takes to switch between speeds if there is a list in either horizontal or vertical speed. Can also be a list of speeds, separated by commas, which will be looped through.
 placements.triggers.vitellary/customwindtrigger.tooltips.catchupSpeed=How fast the wind changes from the previous value. Default is 1.
 placements.triggers.vitellary/customwindtrigger.tooltips.activationType=Special condition for the wind to activate.

--- a/Ahorn/triggers/customWindTrigger.jl
+++ b/Ahorn/triggers/customWindTrigger.jl
@@ -2,7 +2,7 @@ module CustomWindTrigger
 
 using ..Ahorn, Maple
 
-const actTypes = ["", "Seed", "Strawberry", "Keyberry", "Locked Door", "Refill", "Jellyfish", "Theo", "Core Mode (Hot)", "Core Mode (Cold)", "Death"]
+const actTypes = ["", "Seeds", "Strawberry", "Keyberry", "Locked Door", "Refill", "Jellyfish", "Theo", "Core Mode (Hot)", "Core Mode (Cold)", "Death"]
 
 @mapdef Trigger "vitellary/customwindtrigger" Wind(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, speedX::String="0", speedY::String="0", alternationSpeed::String="0", catchupSpeed::Number=1.0, activationType::String="", loop::Bool=true, persist::Bool=false, oneUse::Bool=false, onRoomEnter::Bool=false)
 

--- a/Ahorn/triggers/customWindTrigger.jl
+++ b/Ahorn/triggers/customWindTrigger.jl
@@ -4,7 +4,7 @@ using ..Ahorn, Maple
 
 const actTypes = ["", "Seeds", "Strawberry", "Keyberry", "Locked Door", "Refill", "Jellyfish", "Theo", "Core Mode (Hot)", "Core Mode (Cold)", "Death"]
 
-@mapdef Trigger "vitellary/customwindtrigger" Wind(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, speedX::String="0", speedY::String="0", alternationSpeed::String="0", catchupSpeed::Number=1.0, activationType::String="", loop::Bool=true, persist::Bool=false, oneUse::Bool=false, onRoomEnter::Bool=false)
+@mapdef Trigger "vitellary/customwindtrigger" Wind(x::Integer, y::Integer, width::Integer=Maple.defaultTriggerWidth, height::Integer=Maple.defaultTriggerHeight, speedX::String="0", speedY::String="0", alternationSpeed::String="0", catchupSpeed::Number=1.0, activationType::String="", loop::Bool=true, persist::Bool=false, oneUse::Bool=false, onRoomEnter::Bool=false, fixUpdateDepth::Bool=true)
 
 const placements = Ahorn.PlacementDict(
     "Custom Wind Trigger (Crystalline)" => Ahorn.EntityPlacement(
@@ -16,6 +16,6 @@ const placements = Ahorn.PlacementDict(
 Ahorn.editingOptions(entity::Wind) = Dict{String, Any}(
     "activationType" => actTypes
 )
-Ahorn.editingOrder(entity::Wind) = String["x", "y", "width", "height", "speedX", "speedY", "alternationSpeed", "catchupSpeed", "activationType", "onRoomEnter", "persist", "loop", "oneUse"]
+Ahorn.editingOrder(entity::Wind) = String["x", "y", "width", "height", "speedX", "speedY", "alternationSpeed", "catchupSpeed", "activationType", "onRoomEnter", "persist", "loop", "oneUse", "fixUpdateDepth"]
 
 end

--- a/Code/CustomWindController.cs
+++ b/Code/CustomWindController.cs
@@ -31,7 +31,7 @@ namespace vitmod
             On.Celeste.TheoCrystal.OnPickup -= TheoCrystal_OnPickup;
         }
 
-        public CustomWindController(List<float> speedX, List<float> speedY, List<float> alternateSpeed, float catchupSpeed, string activateType, bool loop, bool persist)
+        public CustomWindController(List<float> speedX, List<float> speedY, List<float> alternateSpeed, float catchupSpeed, string activateType, bool loop, bool persist, bool fixUpdateDepth)
         {
             active = false;
             Tag = Tags.TransitionUpdate;
@@ -42,9 +42,10 @@ namespace vitmod
             this.activateType = activateType;
             this.loop = loop;
             if (persist)
-            {
                 Tag |= Tags.Global | Tags.Persistent;
-            }
+
+            if (fixUpdateDepth)
+                Depth = 1;
         }
 
         public override void Update()
@@ -240,7 +241,7 @@ namespace vitmod
 
         public void DeactivateWind()
         {
-            if (!active) { return; }
+            if (!active) return;
             active = false;
             if (coroutine != null)
             {

--- a/Code/CustomWindTrigger.cs
+++ b/Code/CustomWindTrigger.cs
@@ -18,7 +18,7 @@ namespace vitmod
         {
             speedX = new List<float>();
             string[] speedXStrings = data.Attr("speedX", "0").Split(',');
-            foreach(string sx in speedXStrings)
+            foreach (string sx in speedXStrings)
             {
                 speedX.Add(float.Parse(sx));
             }
@@ -30,7 +30,7 @@ namespace vitmod
             }
             alternateSpeed = new List<float>();
             string[] alternateSpeedStrings = data.Attr("alternationSpeed", "0").Split(',');
-            foreach(string sa in alternateSpeedStrings)
+            foreach (string sa in alternateSpeedStrings)
             {
                 alternateSpeed.Add(float.Parse(sa));
             }
@@ -41,6 +41,7 @@ namespace vitmod
             oneUse = data.Bool("oneUse", false);
             ID = data.ID;
             onRoomEnter = data.Bool("onRoomEnter", false);
+            fixUpdateDepth = data.Bool("fixUpdateDepth", false);
         }
 
         public override void Awake(Scene scene)
@@ -65,7 +66,7 @@ namespace vitmod
             {
                 customWind.RemoveSelf();
             }
-            customWind = new CustomWindController(speedX, speedY, alternateSpeed, catchupSpeed, activateType, loop, persist);
+            customWind = new CustomWindController(speedX, speedY, alternateSpeed, catchupSpeed, activateType, loop, persist, fixUpdateDepth);
             Scene.Add(customWind);
             if (oneUse)
             {
@@ -97,5 +98,7 @@ namespace vitmod
         private int ID;
 
         private bool onRoomEnter;
+
+        private bool fixUpdateDepth;
     }
 }

--- a/Code/vitmod.csproj
+++ b/Code/vitmod.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>vitmod</AssemblyName>
         <RootNamespace>vitmod</RootNamespace>
         <LangVersion>latest</LangVersion>

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -341,7 +341,7 @@ entities.vitellary/dashcodecontroller.attributes.description.index=This sequence
 
 # Custom Wind Trigger
 triggers.vitellary/customwindtrigger.attributes.description.speedX=The horizontal speed of the wind. Can be a list of speeds, separated by commas. For reference, normal wind speed is 4, and strong is 8.
-triggers.vitellary/customwindtrigger.attributes.description.speedY=The vertical speed of the wind. Can be a list of speeds, separated by commas. For reference, normal wind speed is 4, and strong is 8.
+triggers.vitellary/customwindtrigger.attributes.description.speedY=The vertical speed of the wind. Can be a list of speeds, separated by commas. For reference, normal down wind speed is 3, and up is -4.
 triggers.vitellary/customwindtrigger.attributes.description.alternationSpeed=The time, in seconds, that it takes to switch between speeds if there is a list in either horizontal or vertical speed. Can also be a list of speeds, separated by commas, which will be looped through.
 triggers.vitellary/customwindtrigger.attributes.description.catchupSpeed=How fast the wind changes from the previous value. Default is 1.
 triggers.vitellary/customwindtrigger.attributes.description.activationType=Special condition for the wind to activate.

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -349,6 +349,7 @@ triggers.vitellary/customwindtrigger.attributes.description.loop=Whether the win
 triggers.vitellary/customwindtrigger.attributes.description.persist=If true, the wind created will stay after transitioning to a different room or dying. It will still be replaced by other wind triggers.
 triggers.vitellary/customwindtrigger.attributes.description.oneUse=Whether the wind trigger should disappear after being used.
 triggers.vitellary/customwindtrigger.attributes.description.onRoomEnter=Whether the wind trigger should activate immediately when the player enters its room, regardless of the player position.
+triggers.vitellary/customwindtrigger.attributes.description.fixUpdateDepth=Whether the wind should always update before the player. If unchecked, whether it updates before or after the player is able to change depending on load order, resulting in inconsistent behavior.
 
 # Custom Wind Snow
 effects.CrystallineHelper/CustomWindSnow.attributes.description.colors=List of possible colors the wind particles can have, separated by commas.

--- a/Loenn/triggers/custom_wind_trigger.lua
+++ b/Loenn/triggers/custom_wind_trigger.lua
@@ -35,7 +35,8 @@ customWindTrigger.placements = {
             loop = true,
             persist = false,
             oneUse = false,
-            onRoomEnter = false
+            onRoomEnter = false,
+            fixUpdateDepth = true
         }
     }
 }

--- a/Loenn/triggers/custom_wind_trigger.lua
+++ b/Loenn/triggers/custom_wind_trigger.lua
@@ -1,6 +1,6 @@
 local activationTypes = {
     "",
-    "Seed",
+    "Seeds",
     "Strawberry",
     "Keyberry",
     "Locked Door",

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,7 +3,7 @@
   DLL: Code/bin/vitmod.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.5184.0
+      Version: 1.5577.0
   OptionalDependencies:
     - Name: FrostHelper
       Version: 1.21.2


### PR DESCRIPTION
Fixes the 'Seeds' activation type being listed incorrectly as 'Seed' (which does nothing) in the custom wind trigger Lönn and Ahorn plugins.
Also adds a 'fix update depth' option to make custom wind always update before the player (consistent with how vanilla wind behaves after respawning), rather than it being inconsistent depending on load order/whether 'persist' is enabled/if the player has respawned.