### PR TITLE
Add set last booster option to energy boosters

### DIFF
--- a/Ahorn/entities/energyBooster.jl
+++ b/Ahorn/entities/energyBooster.jl
@@ -2,7 +2,7 @@ module FlushelineEnergyBooster
 
 using ..Ahorn, Maple
 
-@mapdef Entity "vitellary/energybooster" EnergyBooster(x::Integer, y::Integer, behaveLikeDash::Bool=false, redirectSpeed::Bool=false, oneUse::Bool=false)
+@mapdef Entity "vitellary/energybooster" EnergyBooster(x::Integer, y::Integer, behaveLikeDash::Bool=false, redirectSpeed::Bool=false, oneUse::Bool=false, setLastBooster::Bool=true)
 
 const placements = Ahorn.PlacementDict(
     "Energy Booster (Crystalline)" => Ahorn.EntityPlacement(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -93,6 +93,7 @@ placements.entities.vitellary/custompuffer.tooltips.tangible=Controls if the puf
 placements.entities.vitellary/energybooster.tooltips.behaveLikeDash=Whether the speed resets after the initial boost unless dashing down diagonal.
 placements.entities.vitellary/energybooster.tooltips.redirectSpeed=Stores your total speed regardless of direction and sends you out exactly that fast in the direction you boost.
 placements.entities.vitellary/energybooster.tooltips.oneUse=Whether the booster can only be used once.
+placements.entities.vitellary/energybooster.tooltips.setLastBooster=Whether to correctly update the internal variable that keeps track of the last booster touched by the player.\nDisabling this can result in unintended behavior when used alongside other custom booster entities.
 
 # Paired Dash Switch
 placements.entities.vitellary/paireddashswitch.tooltips.flag=If specified, this flag will be set to true when the switch is pressed.

--- a/Code/FLCC/EnergyBooster.cs
+++ b/Code/FLCC/EnergyBooster.cs
@@ -30,6 +30,7 @@ namespace vitmod
 		private bool dashBehavior;
 		private bool redirectSpeed;
 		private bool oneUse;
+		private bool setLastBooster;
 
 		public Vector2 PlayerSpeed;
 
@@ -44,6 +45,7 @@ namespace vitmod
 			dashBehavior = data.Bool("behaveLikeDash");
 			redirectSpeed = data.Bool("redirectSpeed");
 			oneUse = data.Bool("oneUse");
+			setLastBooster = data.Bool("setLastBooster", false);
 
 			Depth = -8500;
 			Collider = new Circle(10f, 0f, 2f);
@@ -102,6 +104,8 @@ namespace vitmod
 			{
 				cannotUseTimer = 0.45f;
 				player.boostRed = false;
+				if (setLastBooster)
+					player.LastBooster = player.CurrentBooster = null;
 				player.StateMachine.State = 4;
 				PlayerSpeed = player.Speed;
 				if (player.LiftSpeed != Vector2.Zero)

--- a/Code/vitmod.csproj
+++ b/Code/vitmod.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>vitmod</AssemblyName>
         <RootNamespace>vitmod</RootNamespace>
         <LangVersion>latest</LangVersion>

--- a/Loenn/entities/energy_booster.lua
+++ b/Loenn/entities/energy_booster.lua
@@ -11,6 +11,7 @@ energyBooster.placements = {
             behaveLikeDash = false,
             redirectSpeed = false,
             oneUse = false,
+            setLastBooster = true,
         },
     },
     {
@@ -19,8 +20,14 @@ energyBooster.placements = {
             behaveLikeDash = false,
             redirectSpeed = true,
             oneUse = false,
+            setLastBooster = true,
         },
     },
+}
+
+energyBooster.fieldOrder = {
+    "x", "y",
+    "redirectSpeed", "behaveLikeDash", "oneUse", "setLastBooster",
 }
 
 function energyBooster.sprite(room, entity)

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -213,6 +213,7 @@ entities.vitellary/custompuffer.attributes.description.tangible=Controls if the 
 entities.vitellary/energybooster.attributes.description.behaveLikeDash=Whether the speed resets after the initial boost unless dashing down diagonal.
 entities.vitellary/energybooster.attributes.description.redirectSpeed=Stores your total speed regardless of direction and sends you out exactly that fast in the direction you boost.
 entities.vitellary/energybooster.attributes.description.oneUse=Whether the booster can only be used once.
+entities.vitellary/energybooster.attributes.description.setLastBooster=Whether to correctly update the internal variable that keeps track of the last booster touched by the player.\nDisabling this can result in unintended behavior when used alongside other custom booster entities.
 
 # Paired Dash Switch
 entities.vitellary/paireddashswitch.attributes.description.flag=If specified, this flag will be set to true when the switch is pressed.

--- a/everest.yaml
+++ b/everest.yaml
@@ -3,7 +3,7 @@
   DLL: Code/bin/vitmod.dll
   Dependencies:
     - Name: EverestCore
-      Version: 1.5184.0
+      Version: 1.5577.0
   OptionalDependencies:
     - Name: FrostHelper
       Version: 1.21.2


### PR DESCRIPTION
Adds an option to make energy boosters set the player's `LastBooster` and `CurrentBooster` fields to null, enabled by default on new placements. This fixes some unintended behavior if the player tries to use an energy booster while having previously used a Communal Helper custom booster, since it uses `LastBooster` to determine whether to run some of its custom booster logic.